### PR TITLE
Adjust response formatting to account for unexpected responses

### DIFF
--- a/src/components/SpeechTranscription.js
+++ b/src/components/SpeechTranscription.js
@@ -121,13 +121,21 @@ export default function SpeechTranscription() {
           let values_challenges = resp
             .split("Question:\n")[0]
             .split("Challenges:\n");
-          values_challenges = [
-            values_challenges[0],
-            "Challenges:\n" + values_challenges[1],
-          ];
-          let questions = ["Question:\n" + resp.split("Question:\n").slice(-1)];
-
-          setResponse([...values_challenges, ...questions]);
+          console.log("values_challenges", values_challenges);
+          console.log(values_challenges.length);
+          console.log(resp);
+          if (values_challenges.length == 1) {
+            setResponse([resp]);
+          } else {
+            values_challenges = [
+              values_challenges[0],
+              "Challenges:\n" + values_challenges[1],
+            ];
+            let questions = [
+              "Question:\n" + resp.split("Question:\n").slice(-1),
+            ];
+            setResponse([...values_challenges, ...questions]);
+          }
           setLoading(false);
           setDisabled(false);
           setDisabledSel(false);
@@ -287,7 +295,12 @@ export default function SpeechTranscription() {
                 <Cisco />
               ) //different kind of loading screen
             }
-            {!isLoading && response && (
+            {!isLoading && response && response.length == 1 && (
+              <span className="text-lg">
+                <p className="mt-7 text-primary">{response[0]}</p>
+              </span>
+            )}
+            {!isLoading && response && response.length == 3 && (
               <span className="text-lg">
                 <p className="mt-7 font-bold text-2xl">
                   In your audio response, the following values and challenges


### PR DESCRIPTION
- Example of previous output
<img width="1284" alt="_before" src="https://github.com/Design-and-Partnership-Lab/gatesdemo/assets/60823208/b04ff1b5-6410-4582-a23c-5586907ce706">

- Example of new output
<img width="1269" alt="_after" src="https://github.com/Design-and-Partnership-Lab/gatesdemo/assets/60823208/1291d9a8-680d-45ce-9c0d-e5313c58bb3c">